### PR TITLE
feat: update session notes generation and saving logic

### DIFF
--- a/manifest.template.json
+++ b/manifest.template.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Soulside AI",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Latest Behavioral Health AI for IOPs",
   "permissions": ["storage", "activeTab", "scripting", "background", "tabs", "cookies"],
   "host_permissions": ["<all_urls>"],

--- a/src/content-app/src/Routes/SessionDetails/components/SessionNotes/SessionNotes.tsx
+++ b/src/content-app/src/Routes/SessionDetails/components/SessionNotes/SessionNotes.tsx
@@ -171,7 +171,7 @@ const SessionNotes: React.FC<SessionNotesProps> = ({ session }): React.ReactNode
         };
         dispatch(
           loadSaveSessionNotes(
-            sessionId,
+            session,
             selectedNoteTemplate,
             addedNotesData as SessionNotesType,
             true
@@ -194,7 +194,7 @@ const SessionNotes: React.FC<SessionNotesProps> = ({ session }): React.ReactNode
   }, [sessionNotesData]);
   const saveNotes = () => {
     if (!selectedNoteTemplate || !sessionNotesData) return;
-    dispatch(loadSaveSessionNotes(sessionId, selectedNoteTemplate, sessionNotesData));
+    dispatch(loadSaveSessionNotes(session, selectedNoteTemplate, sessionNotesData));
   };
   const onChangeSessionNotes = (sessionNotes: SessionNotesType) => {
     setSessionNotesData(sessionNotes);

--- a/src/content-app/src/Routes/SessionDetails/components/SessionNotes/components/GenerateNotes/GenerateNotes.tsx
+++ b/src/content-app/src/Routes/SessionDetails/components/SessionNotes/components/GenerateNotes/GenerateNotes.tsx
@@ -104,7 +104,7 @@ const GenerateNotes = ({ session, noteTemplate, regenerate }: GenerateNotesProps
         });
       payload.transcriptCSVRows = transcriptCSVRows;
     }
-    dispatch(loadGenerateSessionNotes(sessionId, noteTemplate, payload));
+    dispatch(loadGenerateSessionNotes(session, noteTemplate, payload));
   };
   return (
     <Box>


### PR DESCRIPTION
- Modify session notes thunks to use full session object instead of just sessionId
- Add fallback session notes creation when no existing notes are found
- Ensure proper handling of different session types (SoulsideSession, IndividualSession)
- Bump extension version to 1.0.8